### PR TITLE
Update allowed OSPF area ID formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ module "aci_l3out" {
 | <a name="input_vrf"></a> [vrf](#input\_vrf) | VRF name. | `string` | n/a | yes |
 | <a name="input_ospf"></a> [ospf](#input\_ospf) | Enable OSPF routing. | `bool` | `false` | no |
 | <a name="input_bgp"></a> [bgp](#input\_bgp) | Enable BGP routing. | `bool` | `false` | no |
-| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format. | `string` | `"backbone"` | no |
+| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an IP address. | `string` | `"backbone"` | no |
 | <a name="input_ospf_area_cost"></a> [ospf\_area\_cost](#input\_ospf\_area\_cost) | OSPF area cost. Minimum value: 1. Maximum value: 16777215. | `number` | `1` | no |
 | <a name="input_ospf_area_type"></a> [ospf\_area\_type](#input\_ospf\_area\_type) | OSPF area type. Choices: `regular`, `stub`, `nssa`. | `string` | `"regular"` | no |
 | <a name="input_l3_multicast_ipv4"></a> [l3\_multicast\_ipv4](#input\_l3\_multicast\_ipv4) | L3 IPv4 Multicast. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ module "aci_l3out" {
 | <a name="input_vrf"></a> [vrf](#input\_vrf) | VRF name. | `string` | n/a | yes |
 | <a name="input_ospf"></a> [ospf](#input\_ospf) | Enable OSPF routing. | `bool` | `false` | no |
 | <a name="input_bgp"></a> [bgp](#input\_bgp) | Enable BGP routing. | `bool` | `false` | no |
-| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an IP address. | `string` | `"backbone"` | no |
+| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format. | `string` | `"backbone"` | no |
 | <a name="input_ospf_area_cost"></a> [ospf\_area\_cost](#input\_ospf\_area\_cost) | OSPF area cost. Minimum value: 1. Maximum value: 16777215. | `number` | `1` | no |
 | <a name="input_ospf_area_type"></a> [ospf\_area\_type](#input\_ospf\_area\_type) | OSPF area type. Choices: `regular`, `stub`, `nssa`. | `string` | `"regular"` | no |
 | <a name="input_l3_multicast_ipv4"></a> [l3\_multicast\_ipv4](#input\_l3\_multicast\_ipv4) | L3 IPv4 Multicast. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ module "aci_l3out" {
 | <a name="input_vrf"></a> [vrf](#input\_vrf) | VRF name. | `string` | n/a | yes |
 | <a name="input_ospf"></a> [ospf](#input\_ospf) | Enable OSPF routing. | `bool` | `false` | no |
 | <a name="input_bgp"></a> [bgp](#input\_bgp) | Enable BGP routing. | `bool` | `false` | no |
-| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone` or a number between 1 and 4294967295. | `string` | `"backbone"` | no |
+| <a name="input_ospf_area"></a> [ospf\_area](#input\_ospf\_area) | OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format. | `string` | `"backbone"` | no |
 | <a name="input_ospf_area_cost"></a> [ospf\_area\_cost](#input\_ospf\_area\_cost) | OSPF area cost. Minimum value: 1. Maximum value: 16777215. | `number` | `1` | no |
 | <a name="input_ospf_area_type"></a> [ospf\_area\_type](#input\_ospf\_area\_type) | OSPF area type. Choices: `regular`, `stub`, `nssa`. | `string` | `"regular"` | no |
 | <a name="input_l3_multicast_ipv4"></a> [l3\_multicast\_ipv4](#input\_l3\_multicast\_ipv4) | L3 IPv4 Multicast. | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "ospf_area" {
   default     = "backbone"
 
   validation {
-    condition     = try(contains(["backbone"], var.ospf_area), false) || (try(tonumber(var.ospf_area), false) != false) || try(can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.ospf_area)), false)
+    condition     = try(contains(["backbone"], var.ospf_area), false) || (try(tonumber(var.ospf_area), false) != false ? tonumber(var.ospf_area) >= 1 && tonumber(var.ospf_area) <= 4294967295 : false) || try(can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.ospf_area)), false)
     error_message = "Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,13 +73,13 @@ variable "bgp" {
 }
 
 variable "ospf_area" {
-  description = "OSPF area. Allowed values are `backbone` or a number between 1 and 4294967295."
+  description = "OSPF area. Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format."
   type        = string
   default     = "backbone"
 
   validation {
-    condition     = try(contains(["backbone"], var.ospf_area), false) || try(can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.ospf_area)), false)
-    error_message = "Allowed values are `backbone` or an id in dotted notation e.g., `0.0.0.10`."
+    condition     = try(contains(["backbone"], var.ospf_area), false) || (try(tonumber(var.ospf_area), false) != false) || try(can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.ospf_area)), false)
+    error_message = "Allowed values are `backbone`, a number between 1 and 4294967295, or an ID in IP address format."
   }
 }
 


### PR DESCRIPTION
There are multiple issues with the Tenant L3Out OSPF area ID in modules 'tenant' and 'aci_l3out'. In module 'tenant', the area ID is modified as:

````
ospf_area = try(tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone")), false) != false ? "0.0.0.${tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone"))}" : "backbone"
````
1. This does not allow to specify the OSPF area ID in the IP address format. Example:
````
      l3outs:
        - name: MY_L3Out_W02_CN
          ospf:
            area: 0.0.0.50
            area_type: nssa
```` 
Because the `tonumber` type conversion function fails, and `ospf_area` is incorrectly set to `backbone`:
````
> try(tonumber("0.0.0.50"), false)
false
````
2. If the area ID is a number > 256, e.g. `257`, it is incorrectly converted to e.g. `0.0.0.257` instead of `0.0.1.1`.

3. The `ospf_area` variable validation in module 'aci_l3out' does not allow a number but only `backbone` or an ID in IP address format.

I propose to first change the validation to allow numbers too. Then, the above `ospf_area` definition in module 'tenant' can be simplified in a second step as follows:

````
ospf_area = lookup(lookup(l3out, "ospf", {}), "area", "backbone")
````